### PR TITLE
Change `pip` to `pip3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Make sure you use `python --version` >= 3.7
 ## Install Required Packages
 Install the required packages with `pip` by running:
 ```
- pip install tk configparser pandas pandastable elytica-dss xlsxwriter
+ pip3 install tk configparser pandas pandastable elytica-dss xlsxwriter
 ```
 ## Run the Program
 If you are running the program from a shell, use:


### PR DESCRIPTION
If the Python version must be 3.7 or higher then pip3 should be the preferred package installer.